### PR TITLE
throw error for response codes >= 400

### DIFF
--- a/ampersand-sync.js
+++ b/ampersand-sync.js
@@ -114,8 +114,14 @@ module.exports = function (method, model, options) {
     // With jQuery.ajax's syntax.
     var promise = new TPromise(function (resolve, reject) {
         request = options.xhr = options.xhrImplementation(ajaxSettings, function (err, resp, body) {
-            if (err) {
-                if (options.error) options.error(resp, 'error', err.message);
+            if (err || resp.statusCode >= 400) {
+                if (options.error) {
+                    try {
+                        body = JSON.parse(body);
+                    } catch(e){}
+                    var message = (err? err.message : (body || "HTTP"+resp.statusCode));
+                    options.error(resp, 'error', message);
+                }
                 reject(err);
             } else {
                 // Parse body as JSON if a string.

--- a/test/index.js
+++ b/test/index.js
@@ -256,3 +256,24 @@ test('Call user provided beforeSend function from model\'s ajaxConfig when no cu
 
     t.end();
 });
+
+test('Call the error callback when status code is >= 400 and do not call success callback', function (t) {
+    t.plan(3);
+    var mockResp = {statusCode: 400};
+    var mockBody = {message: 'Forbidden'};
+    var xhr = sync('read', getStub(), {
+        error: function (resp, type, error) {
+            t.deepEqual(resp, mockResp, 'should be passed through response');
+            t.equal(type, 'error', 'is string \'error\' as per jquery');
+            t.ok(error.message==mockBody.message, 'should return a body with the expected message');
+            t.end();
+        },
+        success: function (resp, type, error) {
+            t.fail('doh');
+        },
+        xhrImplementation: function (ajaxSettings, callback) {
+            callback(null, mockResp, JSON.stringify(mockBody));
+            return {};
+        }
+    });
+});


### PR DESCRIPTION
The ampersand-sync project does a check on the response code detailed here:

https://github.com/AmpersandJS/ampersand-sync/blob/master/core.js#L121

I need this so that my client side code can properly handle these types of responses.
