### PR TITLE
Promise resolve model instead of service body

### DIFF
--- a/core.js
+++ b/core.js
@@ -143,7 +143,7 @@ module.exports = function (xhr) {
                       }
                   }
                   if (options.success) options.success(body, 'success', resp);
-                  resolve(body);
+                  resolve(model);
                   // options.always is deliberately not implemented as it can be easily implemented with promise
               }
           });


### PR DESCRIPTION
The resolve of a promise currently returns the service result parsed as json:
In line 146 of core.js module
```
resolve(body);
```
It would be better to resolve the ampersand model: the raw json returned by a rest service should be never used directly when working with ampersand. So, it could be:
```
resolve(model);
```